### PR TITLE
Node.jsのインストールバージョンをDockerfileで固定する

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update -y && \
   sudo \
   tar
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-RUN apt-get install -y nodejs
-RUN npm install npm@latest -g
+RUN apt-get install -y nodejs npm
+RUN npm install -g n
+RUN n 14.15.1
+RUN apt-get purge -y nodejs npm
+RUN node -v && npm -v
 
 RUN yes | mix local.hex
 RUN mix local.rebar --force


### PR DESCRIPTION
# 概要

Dockerfileで __Node.js__ のインストールバージョンを固定したい

## 現状

現時点で、node -v `v14.15.1` としているが、nodesourceを経由する方法でインストールしているために __マイナーバージョン以下が揺れる可能性がある__

```
RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
RUN apt-get install -y nodejs
RUN npm install npm@latest -g
```

## 対策

バージョン指定インストールできるライブラリを導入する

- いろいろ方法は考えられるが、__`n`__ を採用した
  - Dockerコンテナ環境なのでnodenvまでは不要であると検討